### PR TITLE
feat: add foomatic search index generator script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ package-lock.json
 next-env.d.ts
 
 public/foomatic-db
+/public/search/

--- a/scripts/generate-foomatic-search-index.mjs
+++ b/scripts/generate-foomatic-search-index.mjs
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+
+const DRIVERS_JSON = 'public/foomatic-db/drivers.json';
+const PRINTERS_JSON = 'public/foomatic-db/printers.json';
+const OUTPUT_FILE = 'public/search/foomatic-index.json';
+
+
+function stripHtml(str) {
+  if (str == null || typeof str !== 'string') return '';
+  return str
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+
+function stripHtmlMax(str, maxLength = 500) {
+  const plain = stripHtml(str);
+  if (plain.length <= maxLength) return plain;
+  return plain.slice(0, maxLength);
+}
+
+async function generateSearchIndex() {
+  const cwd = process.cwd();
+
+  const driversPath = path.join(cwd, DRIVERS_JSON);
+  if (!fs.existsSync(driversPath)) {
+    console.warn(`Drivers file not found: ${DRIVERS_JSON}`);
+  }
+  let drivers = [];
+  if (fs.existsSync(driversPath)) {
+    const driversRaw = fs.readFileSync(driversPath, 'utf-8');
+    try {
+      drivers = JSON.parse(driversRaw);
+      if (!Array.isArray(drivers)) drivers = [];
+    } catch (err) {
+      console.error(`Error parsing ${DRIVERS_JSON}:`, err.message);
+    }
+  }
+
+  const printersPath = path.join(cwd, PRINTERS_JSON);
+  if (!fs.existsSync(printersPath)) {
+    console.warn(`Printers file not found: ${PRINTERS_JSON}`);
+  }
+  let printers = [];
+  if (fs.existsSync(printersPath)) {
+    const printersRaw = fs.readFileSync(printersPath, 'utf-8');
+    try {
+      const data = JSON.parse(printersRaw);
+      printers = data?.printers && Array.isArray(data.printers) ? data.printers : [];
+    } catch (err) {
+      console.error(`Error parsing ${PRINTERS_JSON}:`, err.message);
+    }
+  }
+
+  const driverDocs = drivers.map((driver) => ({
+    id: driver.id,
+    type: 'driver',
+    name: driver.name ?? '',
+    driverType: driver.type ?? 'Unknown',
+    description: stripHtmlMax(driver.description ?? '', 500),
+    printerCount: driver.printerCount ?? 0,
+    url: driver.url ?? null,
+  }));
+
+  const printerDocs = printers.map((printer) => ({
+    id: printer.id,
+    type: 'printer',
+    name: printer.model ?? '',
+    manufacturer: printer.manufacturer ?? null,
+    recommendedDriver: printer.recommended_driver ?? null,
+    status: printer.status ?? 'Unknown',
+    functionality: printer.functionality ?? null,
+  }));
+
+  const documents = [...printerDocs, ...driverDocs];
+  const total = documents.length;
+
+  const output = {
+    version: '1.0',
+    generatedAt: new Date().toISOString(),
+    documents,
+    metadata: {
+      documentCount: total,
+      contentTypes: ['printer', 'driver'],
+    },
+  };
+
+  const outDir = path.join(cwd, path.dirname(OUTPUT_FILE));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const outPath = path.join(cwd, OUTPUT_FILE);
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2), 'utf-8');
+
+  console.log(`✓ Generated ${OUTPUT_FILE}`);
+  console.log(`  Document count: ${total}`);
+}
+
+generateSearchIndex().catch((error) => {
+  console.error('Error generating search index:', error);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minisearch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-7.2.0.tgz#3dc30e41e9464b3836553b6d969b656614f8f359"
+  integrity sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"


### PR DESCRIPTION
## What this PR does

Adds a build-time script that generates a static search 
index for the Foomatic printer database.

## Changes
- Add `scripts/generate-foomatic-search-index.mjs` — reads 
  `public/foomatic-db/drivers.json` and `printers.json`, 
  strips HTML from descriptions, and generates 
  `public/search/foomatic-index.json`
- Add `/public/search/` to `.gitignore` — index is generated 
  at build time, not tracked in git

## Results
- 6,657 printer documents
- 259 driver documents  
- 6,916 total documents indexed