### PR TITLE
feat: add MiniSearch runtime and upgrade PrinterSearch with fuzzy search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ package-lock.json
 next-env.d.ts
 
 public/foomatic-db
+/public/search/

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,6 +82,14 @@ export default function HomePage() {
   
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage, setItemsPerPage] = useState(20)
+  const [miniSearchResults, setMiniSearchResults] = useState<import("@/lib/foomatic-search").SearchResult[] | null>(null)
+
+  const handleMiniSearchResults = useCallback(
+    (results: import("@/lib/foomatic-search").SearchResult[] | null) => {
+      setMiniSearchResults(results)
+    },
+    []
+  )
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -191,17 +199,26 @@ export default function HomePage() {
   const filteredPrinters = useMemo(() => {
     let result = printers
 
-    if (selectedManufacturer !== "all") {
-      result = result.filter((p) => p.manufacturer === selectedManufacturer)
-    }
-
-    if (searchQuery) {
-      const queryLower = searchQuery.toLowerCase()
-      result = result.filter(
-        (p) =>
-          (p.model && String(p.model).toLowerCase().includes(queryLower)) ||
-          (p.manufacturer && String(p.manufacturer).toLowerCase().includes(queryLower)),
+    if (miniSearchResults !== null) {
+      const printerIds = new Set(
+        miniSearchResults.filter((r) => r.type === "printer").map((r) => r.id)
       )
+      result = result.filter((p) => printerIds.has(p.id))
+      if (selectedManufacturer !== "all") {
+        result = result.filter((p) => p.manufacturer === selectedManufacturer)
+      }
+    } else {
+      if (selectedManufacturer !== "all") {
+        result = result.filter((p) => p.manufacturer === selectedManufacturer)
+      }
+      if (searchQuery) {
+        const queryLower = searchQuery.toLowerCase()
+        result = result.filter(
+          (p) =>
+            (p.model && String(p.model).toLowerCase().includes(queryLower)) ||
+            (p.manufacturer && String(p.manufacturer).toLowerCase().includes(queryLower)),
+        )
+      }
     }
 
     if (selectedDriverType !== "all") {
@@ -234,7 +251,7 @@ export default function HomePage() {
     }
 
     return result
-  }, [searchQuery, selectedManufacturer, selectedDriverType, selectedMechanismType, selectedSupportLevel, selectedColorCapability, printers])
+  }, [miniSearchResults, searchQuery, selectedManufacturer, selectedDriverType, selectedMechanismType, selectedSupportLevel, selectedColorCapability, printers])
 
   useEffect(() => {
     setCurrentPage(1)
@@ -411,6 +428,7 @@ export default function HomePage() {
             selectedSupportLevel={selectedSupportLevel}
             selectedColorCapability={selectedColorCapability}
             onReset={resetFilters}
+            onMiniSearchResults={handleMiniSearchResults}
           />
         </div>
 

--- a/components/PrinterSearch.tsx
+++ b/components/PrinterSearch.tsx
@@ -6,7 +6,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { useState, useEffect } from "react"
 import { useDebounce } from "@/lib/hooks/use-debounce"
-import { Search, X } from "lucide-react"
+import { Search, X, Loader2 } from "lucide-react"
+import { getSearchInstance, search, type SearchResult } from "@/lib/foomatic-search"
 
 interface PrinterSearchProps {
   manufacturers: string[]
@@ -26,6 +27,7 @@ interface PrinterSearchProps {
   selectedSupportLevel: string
   selectedColorCapability: string
   onReset: () => void
+  onMiniSearchResults?: (results: SearchResult[] | null) => void
 }
 
 export default function PrinterSearch({
@@ -46,13 +48,40 @@ export default function PrinterSearch({
   selectedSupportLevel,
   selectedColorCapability,
   onReset,
+  onMiniSearchResults,
 }: PrinterSearchProps) {
   const [searchQuery, setSearchQuery] = useState("")
+  const [indexLoading, setIndexLoading] = useState(true)
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
 
   useEffect(() => {
-    onSearch(debouncedSearchQuery)
-  }, [debouncedSearchQuery, onSearch])
+    getSearchInstance()
+      .then(() => setIndexLoading(false))
+      .catch((e) => {
+        console.error("Failed to load search index:", e)
+        setIndexLoading(false)
+      })
+  }, [])
+
+  useEffect(() => {
+    const trimmed = debouncedSearchQuery.trim()
+    if (trimmed.length < 2) {
+      onMiniSearchResults?.(null)
+      onSearch("")
+      return
+    }
+    getSearchInstance()
+      .then((instance) => {
+        const results = search(instance, trimmed)
+        onMiniSearchResults?.(results)
+        onSearch(debouncedSearchQuery)
+      })
+      .catch((e) => {
+        console.error("MiniSearch error:", e)
+        onMiniSearchResults?.(null)
+        onSearch(debouncedSearchQuery)
+      })
+  }, [debouncedSearchQuery, onSearch, onMiniSearchResults])
 
   const hasActiveFilters = 
     selectedManufacturer !== "all" ||
@@ -92,8 +121,11 @@ export default function PrinterSearch({
               placeholder="Search by model or make..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 h-12 bg-muted/50 border-border/50 text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-primary/20"
+              className={`pl-10 h-12 bg-muted/50 border-border/50 text-foreground placeholder:text-muted-foreground focus:border-primary/50 focus:ring-primary/20 ${indexLoading ? "pr-10" : ""}`}
             />
+            {indexLoading && (
+              <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+            )}
           </div>
           
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">

--- a/lib/foomatic-search.ts
+++ b/lib/foomatic-search.ts
@@ -1,0 +1,122 @@
+import MiniSearch from "minisearch"
+
+
+export interface SearchResult {
+  id: string
+  type: "printer" | "driver"
+  name: string
+  manufacturer?: string | null
+  driverType?: string | null
+  status?: string | null
+  description?: string | null
+  score: number
+  url?: string | null
+}
+
+export interface FoomaticSearchDocument {
+  id: string
+  type: "printer" | "driver"
+  name: string
+  manufacturer?: string | null
+  driverType?: string | null
+  status?: string | null
+  description?: string | null
+  url?: string | null
+  recommendedDriver?: string | null
+  functionality?: string | null
+  printerCount?: number
+}
+
+
+export interface FoomaticSearchIndex {
+  version: string
+  generatedAt: string
+  documents: FoomaticSearchDocument[]
+  metadata: {
+    documentCount: number
+    contentTypes: string[]
+  }
+}
+
+const INDEX_URL = "/search/foomatic-index.json"
+const SEARCH_FIELDS = ["name", "manufacturer", "driverType", "description"] as const
+const STORE_FIELDS = [
+  "id",
+  "type",
+  "name",
+  "manufacturer",
+  "driverType",
+  "status",
+  "description",
+  "url",
+  "recommendedDriver",
+  "functionality",
+  "printerCount",
+] as const
+
+let searchInstance: MiniSearch<FoomaticSearchDocument> | null = null
+
+
+export async function initSearch(): Promise<MiniSearch<FoomaticSearchDocument>> {
+  const res = await fetch(INDEX_URL)
+  if (!res.ok) {
+    throw new Error(`Failed to load search index: ${res.status} ${res.statusText}`)
+  }
+  const data = (await res.json()) as FoomaticSearchIndex
+  const documents = data?.documents ?? []
+  if (!Array.isArray(documents)) {
+    throw new Error("Invalid search index: documents is not an array")
+  }
+
+  const miniSearch = new MiniSearch<FoomaticSearchDocument>({
+    fields: [...SEARCH_FIELDS],
+    storeFields: [...STORE_FIELDS],
+    searchOptions: {
+      boost: { name: 3, manufacturer: 2 },
+    },
+  })
+  miniSearch.addAll(documents)
+  return miniSearch
+}
+
+export function search(
+  instance: MiniSearch<FoomaticSearchDocument>,
+  query: string,
+  limit = 20
+): SearchResult[] {
+  const trimmed = query.trim()
+  if (trimmed.length < 2) {
+    return []
+  }
+
+  const raw = instance.search(trimmed, {
+    fuzzy: 0.2,
+    prefix: true,
+  })
+  const slice = raw.slice(0, limit)
+  return slice.map((hit) => mapHitToSearchResult(hit))
+}
+
+function mapHitToSearchResult(
+  hit: { id: string; score: number; [key: string]: unknown }
+): SearchResult {
+  return {
+    id: String(hit.id ?? ""),
+    type: hit.type === "driver" ? "driver" : "printer",
+    name: String(hit.name ?? ""),
+    manufacturer: hit.manufacturer != null ? String(hit.manufacturer) : null,
+    driverType: hit.driverType != null ? String(hit.driverType) : null,
+    status: hit.status != null ? String(hit.status) : null,
+    description: hit.description != null ? String(hit.description) : null,
+    score: Number(hit.score) || 0,
+    url: hit.url != null ? String(hit.url) : null,
+  }
+}
+
+export async function getSearchInstance(): Promise<MiniSearch<FoomaticSearchDocument>> {
+  if (searchInstance !== null) {
+    return searchInstance
+  }
+  searchInstance = await initSearch()
+  return searchInstance
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "fast-xml-parser": "^5.3.0",
     "lucide-react": "^0.544.0",
+    "minisearch": "^7.2.0",
     "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/scripts/generate-foomatic-search-index.mjs
+++ b/scripts/generate-foomatic-search-index.mjs
@@ -1,0 +1,104 @@
+import fs from 'fs';
+import path from 'path';
+
+const DRIVERS_JSON = 'public/foomatic-db/drivers.json';
+const PRINTERS_JSON = 'public/foomatic-db/printers.json';
+const OUTPUT_FILE = 'public/search/foomatic-index.json';
+
+
+function stripHtml(str) {
+  if (str == null || typeof str !== 'string') return '';
+  return str
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+
+function stripHtmlMax(str, maxLength = 500) {
+  const plain = stripHtml(str);
+  if (plain.length <= maxLength) return plain;
+  return plain.slice(0, maxLength);
+}
+
+async function generateSearchIndex() {
+  const cwd = process.cwd();
+
+  const driversPath = path.join(cwd, DRIVERS_JSON);
+  if (!fs.existsSync(driversPath)) {
+    console.warn(`Drivers file not found: ${DRIVERS_JSON}`);
+  }
+  let drivers = [];
+  if (fs.existsSync(driversPath)) {
+    const driversRaw = fs.readFileSync(driversPath, 'utf-8');
+    try {
+      drivers = JSON.parse(driversRaw);
+      if (!Array.isArray(drivers)) drivers = [];
+    } catch (err) {
+      console.error(`Error parsing ${DRIVERS_JSON}:`, err.message);
+    }
+  }
+
+  const printersPath = path.join(cwd, PRINTERS_JSON);
+  if (!fs.existsSync(printersPath)) {
+    console.warn(`Printers file not found: ${PRINTERS_JSON}`);
+  }
+  let printers = [];
+  if (fs.existsSync(printersPath)) {
+    const printersRaw = fs.readFileSync(printersPath, 'utf-8');
+    try {
+      const data = JSON.parse(printersRaw);
+      printers = data?.printers && Array.isArray(data.printers) ? data.printers : [];
+    } catch (err) {
+      console.error(`Error parsing ${PRINTERS_JSON}:`, err.message);
+    }
+  }
+
+  const driverDocs = drivers.map((driver) => ({
+    id: driver.id,
+    type: 'driver',
+    name: driver.name ?? '',
+    driverType: driver.type ?? 'Unknown',
+    description: stripHtmlMax(driver.description ?? '', 500),
+    printerCount: driver.printerCount ?? 0,
+    url: driver.url ?? null,
+  }));
+
+  const printerDocs = printers.map((printer) => ({
+    id: printer.id,
+    type: 'printer',
+    name: printer.model ?? '',
+    manufacturer: printer.manufacturer ?? null,
+    recommendedDriver: printer.recommended_driver ?? null,
+    status: printer.status ?? 'Unknown',
+    functionality: printer.functionality ?? null,
+  }));
+
+  const documents = [...printerDocs, ...driverDocs];
+  const total = documents.length;
+
+  const output = {
+    version: '1.0',
+    generatedAt: new Date().toISOString(),
+    documents,
+    metadata: {
+      documentCount: total,
+      contentTypes: ['printer', 'driver'],
+    },
+  };
+
+  const outDir = path.join(cwd, path.dirname(OUTPUT_FILE));
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const outPath = path.join(cwd, OUTPUT_FILE);
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2), 'utf-8');
+
+  console.log(`✓ Generated ${OUTPUT_FILE}`);
+  console.log(`  Document count: ${total}`);
+}
+
+generateSearchIndex().catch((error) => {
+  console.error('Error generating search index:', error);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,6 +2732,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minisearch@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/minisearch/-/minisearch-7.2.0.tgz#3dc30e41e9464b3836553b6d969b656614f8f359"
+  integrity sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"


### PR DESCRIPTION
## What this PR does

Replaces basic string.includes() search with MiniSearch-based 
fuzzy search across all printers and drivers.

## Changes
- Add `lib/foomatic-search.ts` — MiniSearch singleton runtime 
  that loads foomatic-index.json and exposes search()
- Update `components/PrinterSearch.tsx` — preloads index on 
  mount, runs MiniSearch on queries 2+ chars, shows loading 
  spinner while index loads
- Update `app/page.tsx` — wires MiniSearch results into 
  filteredPrinters, falls back to string filter when no 
  active search

## Improvements over previous search
- Fuzzy matching (typo tolerance)
- Relevance scoring (name 3x boost, manufacturer 2x boost)  
- Searches drivers too, not just printers
- prefix: true for partial word matching